### PR TITLE
use no-container so gta car tracker container isn't created upon running

### DIFF
--- a/cli/player.plist
+++ b/cli/player.plist
@@ -4,5 +4,7 @@
 <dict>
   <key>platform-application</key>
   <true/>
+  <key>com.apple.private.security.no-container</key>
+  <true/>
 </dict>
 </plist>

--- a/cli/recorder.plist
+++ b/cli/recorder.plist
@@ -5,6 +5,8 @@
   <!-- FIXME: We also need some private entitlements. -->
   <key>platform-application</key>
   <true/>
+  <key>com.apple.private.security.no-container</key>
+  <true/>
   <key>com.apple.private.tcc.allow</key>
   <array>
     <string>kTCCServiceMicrophone</string>


### PR DESCRIPTION
also, I'd figure i'd add this is a much faster header website to use:
https://headers.cynder.me/index.php